### PR TITLE
Add clustering bin

### DIFF
--- a/bin/www.js
+++ b/bin/www.js
@@ -1,0 +1,19 @@
+var cluster = require('cluster');
+var cleaner = require('../modules/cleaner');
+var config = require('../modules/config');
+
+if (cluster.isMaster) {
+    var cores = require("os").cpus().length;
+    for (var i = cores; i > 0; i--) {
+        cluster.fork();
+    }
+
+    cluster.on('exit', function (worker, code, signal) {
+        console.error('Worker died. Rebooting a new one.');
+        setTimeout(cluster.fork, 100);
+    });
+
+    setInterval(cleaner.run, config.cleaning_interval * 1000);
+} else {
+    require('../server.js')();
+}

--- a/server.js
+++ b/server.js
@@ -92,7 +92,13 @@ function requestHandler(req, res) {
   }
 }
 
-http.createServer(requestHandler).listen(process.env.PORT || 3000);
+var boot = module.exports = function () {
+  http.createServer(requestHandler).listen(process.env.PORT || 3000);
+};
 
-// cleaning worker
-setInterval(clean.run, config.cleaning_interval * 1000);
+if (require.main === module) {
+  boot();
+
+  // cleaning worker
+  setInterval(clean.run, config.cleaning_interval * 1000);
+}


### PR DESCRIPTION
Added a clustering ability (`node bin/www`) to use Node's cluster module across several app instances. Backwards-compatible with existing usage (you can still run `node server` to boot with no clustering). Increases performance on many-cored systems and keeps the service from dying even if one application instance errors out / freezes.