### PR TITLE
Fix some silly parsing URLs

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,10 +42,8 @@ function asset_request(req, res) {
 }
 
 function requestHandler(req, res) {
-  var query = url.parse(req.url).query;
   var request = req;
-  // we need to use url.parse and give the result to url.parse because nodejs
-  request.url = url.parse(req.url, query);
+  request.url = url.parse(req.url, true);
   request.url.query = request.url.query || {};
 
   // remove trailing and double slashes + other junk


### PR DESCRIPTION
`url.parse` just requires "true" to be passed in as its section parameter in order to parse the query string from the URL. The reason it was working before is that by default, parsing just returns the query as a string, which evaluates to be truthy when present. But there's really no reason to have to parse twice :P